### PR TITLE
Update decades.yml

### DIFF
--- a/JJJonesJr33/Plex-Meta-Manager-All/metadata/decades.yml
+++ b/JJJonesJr33/Plex-Meta-Manager-All/metadata/decades.yml
@@ -25,7 +25,6 @@ templates:
       sort_by: release.desc
       url_poster: https://theposterdb.com/api/assets/<<poster>>
       sort_title: +++++_<<collection_name>>
-      collection_order: release
       collection_mode: hide
 
 #############################


### PR DESCRIPTION
The code that has been deleted causes issues - the logs state 'Collection Error: collection_order does not work with Smart Collections' when this line of code is present and this prevents the poster art from downloading correctly.

## Checklist

- [ ] I only edited my own config files.
- [x] I didn't upload any poster or background images to the repository
